### PR TITLE
Update countdown target and hourglass behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,12 +1,8 @@
 const countdownElement = document.getElementById('countdown');
-const targetDate = new Date('2025-11-25T13:35:00');
+const targetDate = new Date('2025-11-22T10:00:00-05:00');
 const confettiContainer = document.getElementById('confetti-container');
 const rootElement = document.documentElement;
-const totalCountdownDuration = Math.max(
-  targetDate.getTime() - Date.now(),
-  0
-);
-const hourglassDuration = totalCountdownDuration > 0 ? totalCountdownDuration : 1;
+const HOURGLASS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 let countdownIntervalId = null;
 
 function setHourglassState(remainingMs) {
@@ -15,20 +11,17 @@ function setHourglassState(remainingMs) {
   }
 
   const remaining = Math.max(remainingMs, 0);
-  const progress = hourglassDuration > 0 ? remaining / hourglassDuration : 0;
-  const topFill = Math.max(0, Math.min(1, progress));
+  const cappedRemaining = Math.min(remaining, HOURGLASS_WINDOW_MS);
+  const topFill = HOURGLASS_WINDOW_MS
+    ? Math.max(0, Math.min(1, cappedRemaining / HOURGLASS_WINDOW_MS))
+    : 0;
   const bottomFill = Math.max(0, Math.min(1, 1 - topFill));
-  const streamActive = remaining > 0 && topFill > 0.001;
-  const streamScale = streamActive ? Math.min(1, 1 - topFill + 0.05) : 0;
+  const streamActive = remaining > 0;
 
   rootElement.style.setProperty('--hourglass-top-fill', topFill.toFixed(4));
   rootElement.style.setProperty(
     '--hourglass-bottom-fill',
     bottomFill.toFixed(4)
-  );
-  rootElement.style.setProperty(
-    '--hourglass-stream-scale',
-    streamScale.toFixed(4)
   );
   rootElement.style.setProperty(
     '--hourglass-stream-opacity',
@@ -40,9 +33,10 @@ function updateCountdown() {
   const now = new Date();
   const diff = targetDate.getTime() - now.getTime();
 
-  setHourglassState(diff);
-
   if (diff <= 0) {
+    // Force the hourglass into its finished state so the bottom bulb is full
+    // and the stream shuts off exactly when the countdown completes.
+    setHourglassState(0);
     countdownElement.textContent = 'THE COLAB IS LIVE!';
     if (countdownIntervalId !== null) {
       clearInterval(countdownIntervalId);
@@ -50,6 +44,8 @@ function updateCountdown() {
     }
     return;
   }
+
+  setHourglassState(diff);
 
   const totalSeconds = Math.floor(diff / 1000);
   const days = Math.floor(totalSeconds / (24 * 60 * 60));

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,6 @@
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --hourglass-top-fill: 1;
   --hourglass-bottom-fill: 0;
-  --hourglass-stream-scale: 0;
   --hourglass-stream-opacity: 0;
 }
 
@@ -141,9 +140,21 @@ body {
   opacity: var(--hourglass-stream-opacity);
   transform-box: fill-box;
   transform-origin: 50% 0%;
-  transform: scaleY(var(--hourglass-stream-scale));
-  transition: opacity 0.6s ease, transform 0.8s ease;
+  animation: hourglassStreamFlow 0.85s ease-in-out infinite;
+  transition: opacity 0.6s ease;
   filter: drop-shadow(0 0 6px rgba(250, 204, 21, 0.55));
+}
+
+@keyframes hourglassStreamFlow {
+  0% {
+    transform: scaleY(0.7);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+  100% {
+    transform: scaleY(0.7);
+  }
 }
 
 .countdown {


### PR DESCRIPTION
## Summary
- point the countdown to Saturday, November 22 at 10:00am EST and treat the hourglass as a seven-day timer leading into the drop
- keep the hourglass sand stream animated so it always looks like sand is flowing while the countdown is active
- force the hourglass into its finished state right when the countdown completes so the bottom bulb is fully packed with sand and the stream stops

## Testing
- Not run (static site)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b00692c4832db8c989bba787c242)