### PR TITLE
Add Node server and start script for Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "countdowntimer",
+  "version": "1.0.0",
+  "description": "Static countdown timer site with minimal Node server for Render deployment.",
+  "main": "server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": ["countdown", "timer", "static", "render"],
+  "author": "",
+  "license": "MIT"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,77 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = __dirname;
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=UTF-8',
+  '.css': 'text/css; charset=UTF-8',
+  '.js': 'application/javascript; charset=UTF-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.json': 'application/json; charset=UTF-8'
+};
+
+function serveFile(filePath, res) {
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+  fs.createReadStream(filePath)
+    .on('open', () => {
+      res.writeHead(200, { 'Content-Type': contentType });
+    })
+    .on('error', (err) => {
+      console.error('Error streaming file %s: %s', filePath, err.message);
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=UTF-8' });
+      res.end('Internal Server Error');
+    })
+    .pipe(res);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health' || req.url === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=UTF-8' });
+    res.end('ok');
+    return;
+  }
+
+  const [pathname] = req.url.split('?');
+  let requestedPath = pathname === '/' ? '/index.html' : pathname;
+  const safePath = path.normalize(requestedPath).replace(/^\.\/+/, '');
+  const filePath = path.join(PUBLIC_DIR, safePath);
+
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=UTF-8' });
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=UTF-8' });
+      res.end('Not Found');
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      const indexPath = path.join(filePath, 'index.html');
+      fs.access(indexPath, fs.constants.R_OK, (accessErr) => {
+        if (accessErr) {
+          res.writeHead(403, { 'Content-Type': 'text/plain; charset=UTF-8' });
+          res.end('Forbidden');
+          return;
+        }
+        serveFile(indexPath, res);
+      });
+      return;
+    }
+
+    serveFile(filePath, res);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/yertttt
+++ b/yertttt
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec npm start


### PR DESCRIPTION
## Summary
- add a lightweight Node HTTP server so the static countdown app can listen on Render's injected port
- define npm metadata and start script to run the server
- provide the `yertttt` entrypoint Render expects so the deployment succeeds

## Testing
- `npm start >/tmp/server.log 2>&1 & echo $! > /tmp/server.pid; sleep 1; tail -n 10 /tmp/server.log; curl -I http://127.0.0.1:3000/; kill $(cat /tmp/server.pid)`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b55c82c4832d9211d250ad91df1e)