### PR TITLE
Adjust layout scaling for small view heights

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,13 @@ body {
   overflow: hidden;
 }
 
+@media (max-height: 820px) {
+  body {
+    transform: scale(0.9);
+    transform-origin: top center;
+  }
+}
+
 body::before {
   content: '';
   position: fixed;


### PR DESCRIPTION
## Summary
- add viewport-height-based scaling to zoom out the layout when space is limited so the countdown stays visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de54f0654832d91497a2081c93f0c)