### PR TITLE
Valentine's theme: remove hourglass, update countdown to Feb 13 2026 07:57 CST

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,154 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Christmas Countdown</title>
+    <title>Valentine's Countdown</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="garland" aria-hidden="true"></div>
-    <div class="scene">
-      <img
-        class="snowbank"
-        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 960 360'%3E%3Cdefs%3E%3ClinearGradient id='sky' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0%' stop-color='%23213c52'/%3E%3Cstop offset='100%' stop-color='%23071822'/%3E%3C/linearGradient%3E%3ClinearGradient id='snow' x1='0' y1='0' x2='1' y2='0'%3E%3Cstop offset='0%' stop-color='%23f8fafc'/%3E%3Cstop offset='100%' stop-color='%23dbeafe'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='960' height='360' fill='url(%23sky)'/%3E%3Cpath d='M-40 220Q160 140 320 196t260-6q160-56 320 30v140H-40Z' fill='url(%23snow)' opacity='0.95'/%3E%3Ccircle cx='220' cy='210' r='14' fill='%23d9f99d'/%3E%3Ccircle cx='520' cy='220' r='14' fill='%23fb7185'/%3E%3Ccircle cx='720' cy='212' r='14' fill='%23fef08a'/%3E%3C/svg%3E"
-        alt="Snowy backdrop"
-      />
-      <img
-        class="tree"
-        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 320'%3E%3Cdefs%3E%3ClinearGradient id='pine' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0%' stop-color='%234cad4a'/%3E%3Cstop offset='100%' stop-color='%231f6f3f'/%3E%3C/linearGradient%3E%3ClinearGradient id='snow' x1='0' y1='0' x2='1' y2='0'%3E%3Cstop offset='0%' stop-color='%23f8fafc'/%3E%3Cstop offset='100%' stop-color='%23e2e8f0'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect x='98' y='250' width='44' height='56' rx='8' fill='%238c4b16'/%3E%3Cpolygon points='120,26 32,140 92,140 48,200 108,200 60,262 120,262 180,262 132,200 192,200 148,140 208,140' fill='url(%23pine)' stroke='%23135d2c' stroke-width='8' stroke-linejoin='round'/%3E%3Cpath d='M120 68c-30 18-52 32-64 60 34-16 64-24 128-6-12-34-40-46-64-54Z' fill='url(%23snow)' opacity='0.82'/%3E%3Ccircle cx='120' cy='46' r='10' fill='%23fbbf24' stroke='%23eab308' stroke-width='6'/%3E%3Cg fill='%23fef08a'%3E%3Ccircle cx='78' cy='166' r='8'/%3E%3Ccircle cx='110' cy='130' r='8'/%3E%3Ccircle cx='148' cy='158' r='8'/%3E%3Ccircle cx='124' cy='196' r='8'/%3E%3Ccircle cx='156' cy='202' r='8'/%3E%3C/g%3E%3Cg fill='%23f472b6'%3E%3Ccircle cx='98' cy='182' r='7'/%3E%3Ccircle cx='132' cy='178' r='7'/%3E%3Ccircle cx='154' cy='132' r='7'/%3E%3C/g%3E%3C/svg%3E"
-        alt="Decorated Christmas tree"
-      />
-      <img
-        class="gifts"
-        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 360 160'%3E%3Cg stroke='%2322563b' stroke-width='8' stroke-linejoin='round'%3E%3Crect x='18' y='64' width='110' height='84' rx='12' fill='%23fef08a'/%3E%3Crect x='70' y='36' width='64' height='112' rx='12' fill='%23fb7185'/%3E%3Crect x='140' y='70' width='110' height='78' rx='14' fill='%230ea5e9'/%3E%3Crect x='196' y='48' width='70' height='100' rx='14' fill='%23f43f5e'/%3E%3Crect x='256' y='84' width='86' height='64' rx='14' fill='%23256d1b'/%3E%3C/g%3E%3Cg fill='%23fefefe'%3E%3Crect x='66' y='36' width='12' height='112' rx='5'/%3E%3Crect x='18' y='102' width='110' height='12' rx='5'/%3E%3Crect x='196' y='92' width='70' height='12' rx='5'/%3E%3Crect x='204' y='48' width='12' height='100' rx='5'/%3E%3Crect x='300' y='84' width='12' height='64' rx='5'/%3E%3Crect x='256' y='120' width='86' height='12' rx='5'/%3E%3C/g%3E%3C/svg%3E"
-        alt="Presents under the tree"
-      />
-      <img
-        class="grinch"
-        src="https://raw.githubusercontent.com/VeganPorkChop/countDownTimer/main/grinch.jpg"
-        alt="The Grinch in a Santa hat holding an ornament"
-      />
-    </div>
+    <div class="hearts" aria-hidden="true"></div>
     <main class="hero">
       <h1 class="headline">
         <span class="names">MACEY + GRAHAM</span>
-        <span class="tagline">CHRISTMAS COLAB IN</span>
+        <span class="tagline">VALENTINE'S DAY IN</span>
       </h1>
-      <div class="hourglass" aria-hidden="true">
-        <svg
-          class="hourglass-art"
-          viewBox="0 0 120 220"
-          xmlns="http://www.w3.org/2000/svg"
-          role="presentation"
-        >
-          <defs>
-            <linearGradient
-              id="hourglass-sand-gradient"
-              x1="0%"
-              y1="0%"
-              x2="0%"
-              y2="100%"
-            >
-              <stop offset="0%" stop-color="#c0392b" />
-              <stop offset="100%" stop-color="#256d1b" />
-            </linearGradient>
-            <filter id="hourglass-sand-grain" x="-20%" y="-20%" width="140%" height="140%">
-              <feTurbulence
-                type="fractalNoise"
-                baseFrequency="1.2"
-                numOctaves="2"
-                seed="14"
-                result="noise"
-              />
-              <feColorMatrix
-                in="noise"
-                type="matrix"
-                values="0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0.32 0"
-                result="noiseAlpha"
-              />
-              <feComposite
-                in="SourceGraphic"
-                in2="noiseAlpha"
-                operator="arithmetic"
-                k1="1"
-                k2="0.25"
-                k3="0"
-                k4="0"
-              />
-            </filter>
-            <clipPath id="hourglass-top-bulb">
-              <path d="M24 18H96L68 110H52Z" />
-            </clipPath>
-            <clipPath id="hourglass-bottom-bulb">
-              <path d="M24 202H96L68 110H52Z" />
-            </clipPath>
-            <linearGradient
-              id="hourglass-stream-gradient"
-              x1="0%"
-              y1="0%"
-              x2="0%"
-              y2="100%"
-            >
-              <stop offset="0%" stop-color="#fef08a" />
-              <stop offset="55%" stop-color="#fbbf24" />
-              <stop offset="100%" stop-color="#f59e0b" />
-            </linearGradient>
-          </defs>
-          <g class="hourglass-glass">
-            <path
-              class="hourglass-frame"
-              d="M24 18H96L70 110L96 202H24L50 110Z"
-            />
-            <path
-              class="hourglass-inner"
-              d="M30 24H90L66.5 110L90 196H30L53.5 110Z"
-            />
-            <path
-              class="hourglass-highlight"
-              d="M36 30C40 26 52 22 60 22C68 22 78 24 84 28L70 110Z"
-            />
-            <path
-              class="hourglass-highlight hourglass-highlight--bottom"
-              d="M36 190C40 194 52 198 60 198C68 198 78 196 84 192L70 110Z"
-            />
-          </g>
-          <g class="hourglass-sand hourglass-sand--top" clip-path="url(#hourglass-top-bulb)">
-            <rect
-              class="hourglass-sand-fill"
-              x="24"
-              y="18"
-              width="72"
-              height="92"
-              rx="6"
-              filter="url(#hourglass-sand-grain)"
-            />
-            <path
-              class="hourglass-sand-surface"
-              d="M24 42Q60 32 96 42L96 18H24Z"
-              filter="url(#hourglass-sand-grain)"
-            />
-          </g>
-          <g class="hourglass-sand hourglass-sand--bottom" clip-path="url(#hourglass-bottom-bulb)">
-            <rect
-              class="hourglass-sand-fill"
-              x="24"
-              y="110"
-              width="72"
-              height="92"
-              rx="6"
-              filter="url(#hourglass-sand-grain)"
-            />
-            <path
-              class="hourglass-sand-mound"
-              d="M24 186Q60 174 96 186L96 202H24Z"
-              filter="url(#hourglass-sand-grain)"
-            />
-          </g>
-          <path class="hourglass-stream" d="M60 108L60 128" />
-        </svg>
-      </div>
       <div id="countdown" class="countdown">Loading…</div>
     </main>
     <div id="confetti-container" aria-hidden="true"></div>

--- a/script.js
+++ b/script.js
@@ -1,49 +1,20 @@
 const countdownElement = document.getElementById('countdown');
-const targetDate = new Date('2025-12-11T13:34:00-05:00');
+const targetDate = new Date('2026-02-13T07:57:00-06:00');
 const confettiContainer = document.getElementById('confetti-container');
-const rootElement = document.documentElement;
-const HOURGLASS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 let countdownIntervalId = null;
-
-function setHourglassState(remainingMs) {
-  if (!rootElement) {
-    return;
-  }
-
-  const remaining = Math.max(remainingMs, 0);
-  const cappedRemaining = Math.min(remaining, HOURGLASS_WINDOW_MS);
-  const topFill = HOURGLASS_WINDOW_MS
-    ? Math.max(0, Math.min(1, cappedRemaining / HOURGLASS_WINDOW_MS))
-    : 0;
-  const bottomFill = Math.max(0, Math.min(1, 1 - topFill));
-  const streamActive = remaining > 0;
-
-  rootElement.style.setProperty('--hourglass-top-fill', topFill.toFixed(4));
-  rootElement.style.setProperty(
-    '--hourglass-bottom-fill',
-    bottomFill.toFixed(4)
-  );
-  rootElement.style.setProperty(
-    '--hourglass-stream-opacity',
-    streamActive ? '1' : '0'
-  );
-}
 
 function updateCountdown() {
   const now = new Date();
   const diff = targetDate.getTime() - now.getTime();
 
   if (diff <= 0) {
-    setHourglassState(0);
-    countdownElement.textContent = 'THE HOLIDAY COLAB IS LIVE!';
+    countdownElement.textContent = "VALENTINE'S DAY IS HERE!";
     if (countdownIntervalId !== null) {
       clearInterval(countdownIntervalId);
       countdownIntervalId = null;
     }
     return;
   }
-
-  setHourglassState(diff);
 
   const totalSeconds = Math.floor(diff / 1000);
   const days = Math.floor(totalSeconds / (24 * 60 * 60));
@@ -75,7 +46,7 @@ function createConfetti() {
     return;
   }
 
-  const colors = ['#b7ff53', '#f43f5e', '#0ea5e9', '#f59e0b', '#16a34a'];
+  const colors = ['#f472b6', '#fb7185', '#fda4af', '#fecdd3', '#f43f5e'];
   const confettiCount = 150;
 
   for (let i = 0; i < confettiCount; i += 1) {

--- a/styles.css
+++ b/styles.css
@@ -3,9 +3,6 @@
 :root {
   color-scheme: dark;
   font-family: 'Poppins', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  --hourglass-top-fill: 1;
-  --hourglass-bottom-fill: 0;
-  --hourglass-stream-opacity: 0;
 }
 
 * {
@@ -20,10 +17,10 @@ body {
   align-items: center;
   justify-content: center;
   position: relative;
-  background: radial-gradient(circle at 14% 18%, rgba(255, 255, 255, 0.18), transparent 30%),
-    radial-gradient(circle at 86% 18%, rgba(244, 63, 94, 0.12), transparent 32%),
-    radial-gradient(circle at 50% 82%, rgba(22, 163, 74, 0.15), transparent 40%),
-    linear-gradient(160deg, #021018 0%, #0b1f27 45%, #041018 100%);
+  background: radial-gradient(circle at 18% 18%, rgba(248, 113, 113, 0.28), transparent 40%),
+    radial-gradient(circle at 82% 12%, rgba(244, 114, 182, 0.22), transparent 36%),
+    radial-gradient(circle at 50% 80%, rgba(251, 113, 133, 0.22), transparent 46%),
+    linear-gradient(160deg, #1b0b1c 0%, #2c1026 45%, #0f0a17 100%);
   color: #f8fafc;
   text-align: center;
   padding: 2.4rem;
@@ -43,12 +40,12 @@ body::before {
   inset: 0;
   z-index: -2;
   pointer-events: none;
-  background-image: radial-gradient(circle at 14% 22%, rgba(255, 255, 255, 0.55), transparent 46%),
-    radial-gradient(circle at 80% 78%, rgba(183, 255, 83, 0.26), transparent 50%),
-    radial-gradient(circle at 64% 36%, rgba(248, 250, 252, 0.26), transparent 44%),
-    linear-gradient(135deg, rgba(4, 28, 24, 0.6), rgba(11, 33, 40, 0.2));
+  background-image: radial-gradient(circle at 14% 22%, rgba(255, 255, 255, 0.38), transparent 46%),
+    radial-gradient(circle at 80% 78%, rgba(244, 114, 182, 0.24), transparent 50%),
+    radial-gradient(circle at 64% 36%, rgba(248, 250, 252, 0.22), transparent 44%),
+    linear-gradient(135deg, rgba(27, 11, 28, 0.6), rgba(48, 16, 38, 0.2));
   mix-blend-mode: screen;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 
 body::after {
@@ -57,9 +54,9 @@ body::after {
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cg fill='none' stroke='%23b7ff53' stroke-width='12' stroke-linecap='round'%3E%3Cpath d='M-10 62C28 18 96 10 150 30s64 70 30 110-106 48-148 22S-32 106-10 62Z'/%3E%3C/g%3E%3Cg fill='none' stroke='%23f43f5e' stroke-width='10' stroke-linecap='round'%3E%3Cpath d='M20 40c18 10 26 38 10 58S6 132 22 146s42 16 76 4 60-40 72-74'/%3E%3C/g%3E%3Cg fill='%23fef08a' opacity='0.7'%3E%3Ccircle cx='30' cy='64' r='10'/%3E%3Ccircle cx='98' cy='32' r='10'/%3E%3Ccircle cx='160' cy='62' r='10'/%3E%3Ccircle cx='88' cy='140' r='10'/%3E%3Ccircle cx='36' cy='158' r='10'/%3E%3C/g%3E%3C/svg%3E");
-  background-size: 260px 260px;
-  opacity: 0.8;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 160 160'%3E%3Cpath d='M80 138C48 112 24 92 24 62c0-18 14-32 32-32 12 0 22 6 28 16 6-10 16-16 28-16 18 0 32 14 32 32 0 30-24 50-56 76Z' fill='%23fb7185' fill-opacity='0.24'/%3E%3Ccircle cx='30' cy='30' r='8' fill='%23fda4af' fill-opacity='0.6'/%3E%3Ccircle cx='124' cy='24' r='10' fill='%23fecdd3' fill-opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 220px 220px;
+  opacity: 0.75;
 }
 
 #confetti-container {
@@ -103,8 +100,8 @@ body::after {
   align-items: center;
   padding: 1.6rem 1.9rem 2rem;
   filter: drop-shadow(0 20px 38px rgba(0, 0, 0, 0.35));
-  background: linear-gradient(160deg, rgba(6, 62, 42, 0.62), rgba(14, 32, 46, 0.68));
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(160deg, rgba(74, 22, 52, 0.7), rgba(35, 12, 34, 0.78));
+  border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 26px;
   backdrop-filter: blur(8px);
 }
@@ -116,8 +113,8 @@ body::after {
   text-transform: uppercase;
   line-height: 1.15;
   color: #fefefe;
-  text-shadow: 0 6px 18px rgba(0, 0, 0, 0.5), 0 0 24px rgba(183, 255, 83, 0.35);
-  border-bottom: 4px solid rgba(244, 63, 94, 0.65);
+  text-shadow: 0 6px 18px rgba(0, 0, 0, 0.5), 0 0 24px rgba(248, 113, 133, 0.35);
+  border-bottom: 4px solid rgba(248, 113, 133, 0.75);
   padding-bottom: 0.35em;
 }
 
@@ -130,117 +127,8 @@ body::after {
   font-size: clamp(2.1rem, 6vw, 4.4rem);
   font-weight: 800;
   letter-spacing: 0.28em;
-  color: #b7ff53;
-  text-shadow: 0 0 14px rgba(183, 255, 83, 0.45);
-}
-
-.hourglass {
-  position: relative;
-  display: grid;
-  place-items: center;
-  filter: drop-shadow(0 20px 36px rgba(0, 0, 0, 0.55));
-  background: radial-gradient(circle at 12% 14%, rgba(244, 63, 94, 0.22), rgba(37, 109, 27, 0.16)),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
-  padding: 1.6rem 1.4rem;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  backdrop-filter: blur(7px);
-}
-
-.hourglass-art {
-  width: clamp(170px, 32vw, 240px);
-  height: auto;
-}
-
-.hourglass-glass {
-  fill: none;
-}
-
-.hourglass-frame {
-  fill: none;
-  stroke: rgba(226, 232, 240, 0.9);
-  stroke-width: 6;
-  stroke-linejoin: round;
-}
-
-.hourglass-inner {
-  fill: rgba(15, 23, 42, 0.38);
-}
-
-.hourglass-highlight {
-  fill: rgba(255, 255, 255, 0.16);
-}
-
-.hourglass-highlight--bottom {
-  opacity: 0.55;
-}
-
-.hourglass-sand {
-  transform-box: fill-box;
-  transition: transform 1.6s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.hourglass-sand--top {
-  transform-origin: 50% 100%;
-  transform: scaleY(var(--hourglass-top-fill));
-}
-
-.hourglass-sand--bottom {
-  transform-origin: 50% 100%;
-  transform: scaleY(var(--hourglass-bottom-fill));
-}
-
-.hourglass-sand-fill,
-.hourglass-sand-mound,
-.hourglass-sand-surface {
-  fill: url(#hourglass-sand-gradient);
-}
-
-.hourglass-sand-fill {
-  opacity: 0.92;
-}
-
-.hourglass-sand-mound {
-  fill-opacity: 0.9;
-}
-
-.hourglass-sand-surface {
-  fill-opacity: 0.78;
-}
-
-.hourglass-stream {
-  fill: none;
-  stroke: url(#hourglass-stream-gradient);
-  stroke-width: 5.5;
-  stroke-linecap: round;
-  opacity: var(--hourglass-stream-opacity);
-  stroke-dasharray: 9 11;
-  animation:
-    hourglassStreamPulse 1.2s ease-in-out infinite,
-    hourglassStreamFall 0.8s linear infinite;
-  transition: opacity 0.6s ease;
-  filter: drop-shadow(0 0 10px rgba(250, 204, 21, 0.4));
-}
-
-@keyframes hourglassStreamPulse {
-  0%,
-  100% {
-    stroke-width: 5.5;
-    filter: drop-shadow(0 0 10px rgba(250, 204, 21, 0.42));
-  }
-  50% {
-    stroke-width: 6.6;
-    filter: drop-shadow(0 0 16px rgba(250, 204, 21, 0.52));
-  }
-}
-
-@keyframes hourglassStreamFall {
-  from {
-    stroke-dashoffset: 0;
-  }
-  to {
-    stroke-dashoffset: -40;
-  }
+  color: #fda4af;
+  text-shadow: 0 0 14px rgba(244, 114, 182, 0.5);
 }
 
 .countdown {
@@ -266,75 +154,16 @@ body::after {
   }
 }
 
-.garland {
+.hearts {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 140'%3E%3Cg fill='none' stroke='%230f2b23' stroke-width='16' stroke-linecap='round'%3E%3Cpath d='M-20 44c44 30 128 32 204 6s148-28 216 2 132 32 212 6 168-30 224 4'/%3E%3C/g%3E%3Cg fill='none' stroke='%23b7ff53' stroke-width='22' stroke-linecap='round'%3E%3Cpath d='M28 54c18 32 44 36 62 6s44-28 62 0 44 28 62 0 44-28 62 0 44 28 62 0 44-28 62 0 44 28 62 0 44-28 62 0 44 28 62 0 44-28 62 0 44 28 62 0 44-28 62 0'/%3E%3C/g%3E%3Cg fill='%23f43f5e' stroke='%23b91c1c' stroke-width='7'%3E%3Ccircle cx='60' cy='96' r='18'/%3E%3Ccircle cx='168' cy='96' r='18'/%3E%3Ccircle cx='276' cy='96' r='18'/%3E%3Ccircle cx='384' cy='96' r='18'/%3E%3Ccircle cx='492' cy='96' r='18'/%3E%3Ccircle cx='600' cy='96' r='18'/%3E%3Ccircle cx='708' cy='96' r='18'/%3E%3Ccircle cx='816' cy='96' r='18'/%3E%3C/g%3E%3Cg fill='%23256d1b' stroke='%23145a12' stroke-width='7'%3E%3Ccircle cx='114' cy='114' r='16'/%3E%3Ccircle cx='222' cy='114' r='16'/%3E%3Ccircle cx='330' cy='114' r='16'/%3E%3Ccircle cx='438' cy='114' r='16'/%3E%3Ccircle cx='546' cy='114' r='16'/%3E%3Ccircle cx='654' cy='114' r='16'/%3E%3Ccircle cx='762' cy='114' r='16'/%3E%3C/g%3E%3Cg fill='%23fef08a' stroke='%23f59e0b' stroke-width='7'%3E%3Ccircle cx='6' cy='114' r='14'/%3E%3Ccircle cx='96' cy='114' r='14'/%3E%3Ccircle cx='186' cy='114' r='14'/%3E%3Ccircle cx='276' cy='114' r='14'/%3E%3Ccircle cx='366' cy='114' r='14'/%3E%3Ccircle cx='456' cy='114' r='14'/%3E%3Ccircle cx='546' cy='114' r='14'/%3E%3Ccircle cx='636' cy='114' r='14'/%3E%3Ccircle cx='726' cy='114' r='14'/%3E%3Ccircle cx='816' cy='114' r='14'/%3E%3C/g%3E%3C/svg%3E");
-  background-repeat: repeat-x;
-  background-size: 800px 120px;
-  background-position: top center;
-  z-index: 2;
-  opacity: 0.9;
-}
-
-.scene {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  display: grid;
-  place-items: center;
   z-index: 0;
-}
-
-.scene img {
-  position: absolute;
-  filter: drop-shadow(0 16px 22px rgba(0, 0, 0, 0.4));
-  user-select: none;
-  animation: float 10s ease-in-out infinite;
-}
-
-.scene .snowbank {
-  width: min(1200px, 130vw);
-  bottom: -6rem;
-  left: 50%;
-  transform: translateX(-50%);
-  animation: none;
-}
-
-.scene .tree {
-  width: clamp(220px, 32vw, 320px);
-  bottom: 1.6rem;
-  left: 12%;
-  animation-delay: 0.6s;
-}
-
-.scene .gifts {
-  width: clamp(260px, 42vw, 380px);
-  bottom: 0.4rem;
-  left: 44%;
-  transform: translateX(-50%);
-  animation-delay: 1.1s;
-}
-
-.scene .grinch {
-  width: clamp(200px, 32vw, 300px);
-  bottom: 1.4rem;
-  right: 8%;
-  animation-delay: 1.4s;
-  border-radius: 18px;
-  background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.18), transparent 48%),
-    linear-gradient(145deg, rgba(15, 23, 42, 0.8), rgba(15, 118, 110, 0.5));
-  border: 6px solid rgba(241, 245, 249, 0.8);
-  object-fit: cover;
-}
-
-@keyframes float {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-12px);
-  }
+  opacity: 0.7;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(244, 114, 182, 0.35), transparent 24%),
+    radial-gradient(circle at 78% 24%, rgba(251, 113, 133, 0.35), transparent 28%),
+    radial-gradient(circle at 32% 78%, rgba(253, 164, 175, 0.28), transparent 32%),
+    radial-gradient(circle at 70% 74%, rgba(254, 205, 211, 0.22), transparent 30%);
+  filter: blur(0.5px);
 }


### PR DESCRIPTION
### Motivation
- Replace the existing Christmas-themed countdown with a Valentine’s Day visual and messaging.
- Remove the hourglass visual and its dynamic fill logic to simplify the UI.
- Reset the countdown target to Feb 13, 2026 at 7:57 AM CST and update the live message for the event.
- Update confetti and color palette to pink/red Valentine’s colors for a cohesive theme.

### Description
- Reworked `index.html` to remove the garland/scene images and the hourglass SVG, and added a `hearts` background element and updated headline/tagline text.
- Updated `script.js` to set `targetDate` to `2026-02-13T07:57:00-06:00`, remove hourglass state logic, and change the end message to `"VALENTINE'S DAY IS HERE!"` and confetti color palette.
- Updated `styles.css` to remove hourglass-related CSS and Christmas visuals, and add Valentine’s gradients, heart background, and adjusted typography accents.
- Key files modified: `index.html`, `script.js`, and `styles.css`.

### Testing
- Performed a visual smoke test by serving the site with `python -m http.server` and capturing a screenshot with Playwright, which completed successfully.
- No unit or integration tests were present or executed for these static UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696408ed33cc832d9a45824f400331cc)