### PR TITLE
Add postinstall to expose yertttt in node_modules/.bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "type": "commonjs",
   "scripts": {
+    "postinstall": "chmod +x yertttt && mkdir -p node_modules/.bin && ln -sf \"$PWD/yertttt\" node_modules/.bin/yertttt",
     "start": "node server.js",
     "yertttt": "./yertttt"
   },


### PR DESCRIPTION
### Motivation
- Ensure the repository-local `yertttt` helper script is executable and available on platforms (like Render) that invoke scripts from `node_modules/.bin`.
- Prevent deploy failures caused by the platform attempting to run the `yertttt` script but not finding it in the usual `node_modules/.bin` path.

### Description
- Added a `postinstall` script to `package.json` that runs `chmod +x yertttt && mkdir -p node_modules/.bin && ln -sf "$PWD/yertttt" node_modules/.bin/yertttt`.
- The change ensures `yertttt` is marked executable and a symlink is created at `node_modules/.bin/yertttt` so it can be invoked as a package script or by the runtime.
- Only `package.json` was modified to add the `postinstall` entry.

### Testing
- No automated unit tests were run against the modified code.
- A prior observed `yarn install`/build in the deploy log completed successfully before the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641208f748832d9e029e2333454130)